### PR TITLE
Issue #7 & #8 - Geolocation and Protecting Submitting Twice

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,4 +1,20 @@
 class Submission < ApplicationRecord
   has_many :anecdotes
   has_many :researches
+  before_save :geocode_location
+  validate :double_submit_same_illness
+
+private
+
+  def geocode_location
+    location = Geocoder.search(self.ip_address, ip_address: true).first
+    self.city = location.data["city"]
+    self.zip_code = location.data["zip_code"]
+  end
+
+  def double_submit_same_illness
+    if Submission.exists?(cookie: self.cookie, illness: self.illness)
+      errors.add(:cookie, "User already submitted this illness.")
+    end
+  end
 end


### PR DESCRIPTION
Delivers: https://github.com/ContextualCamouflage/contextual-camoflage-api/issues/7
I'm validating that the user is submitting with a unique cookie and illness. If not, the record is not saved. 

Delivers: https://github.com/ContextualCamouflage/contextual-camoflage-api/issues/8
I'm taking the IP from the frontend and saving both the city and the zipcode. 